### PR TITLE
readme: Install command should use base env

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Installation
 
 .. code-block:: console
 
-   $ conda install -c omegacen conda-depgraph
+   $ conda install -n base -c omegacen conda-depgraph
 
 It can either be installed into its own conda environment, or into the base
 environment.


### PR DESCRIPTION
Lovely tool!  Works great for me.

Presumably most users will want it installed to the `base` environment.  Otherwise (since `conda` is a dependency of `conda-depgraph`), the `install` command will attempt to install `conda` into a non-base environment.  That seems likely to cause confusion.