### PR TITLE
Break the cycle between python and pip

### DIFF
--- a/src/conda_depgraph/conda_facade.py
+++ b/src/conda_depgraph/conda_facade.py
@@ -72,5 +72,11 @@ def _package_datas_to_graph(datas):
             g.add_node(n)
             for d in p.get('depends', []):
                 o, *_ = d.split(' ')
-                g.add_edge(n, o)
+
+                # Break the circular dependency between python and pip.
+                # Otherwise, pip appears as a dependency of every python package.
+                # FWIW, conda's own toposort does the same thing:
+                # https://github.com/conda/conda/blob/e9a5056/conda/common/toposort.py#L101-L109
+                if (n, o) != ('python', 'pip'):
+                    g.add_edge(n, o)
     return g


### PR DESCRIPTION
Long ago, the conda team decided to [introduce an artificial dependency between python and pip][2], to ensure that no users ever install `python` without also installing `pip`.  That means that the dependency graph for every python package now contains a cycle: `python` <--> `pip`.

That cycle introduces noise in the `conda depgraph` output for any python package.  I think it's better for most users if that dependency is simply removed from the graph before visualizing it.

For example, here is the output for `conda depgraph out click` with and without the cycle.  

<details>

<summary>click dependencies (without pip)</summary>

```
                 ┌─────┐
                 │click│
                 └──┬──┘
                    │
                    v
           ┌─────────────────┐
           │     python      │
           └┬┬┬─────┬──┬─┬─┬┬┘
            │││     │  │ │ ││
            │││     │  │ │ │└──────┐
      ┌─────┼┘│     │  │ │ │       │
      │     │ │     │  │ │ │       │
      v     │ │     │  │ │ │       │
  ┌──────┐  │ │     │  │ │ │       │
  │sqlite│  │ │     │  │ │ │       │
  └─┬──┬─┘  │ │     │  │ │ │       │
    │  │    │ │     │  │ │ │       │
    │  └───┐│ │     │  │ │ └────┐  │
    │ ┌────┼┘ │     │  │ │      │  │
    │ │    v  v     │  │ │      │  │
    │ │ ┌────────┐  │  │ │      │  │
    │ │ │readline│  │  │ │      │  │
    │ │ └────┬───┘  │  │ │      │  │
    │ └────┐ │┌─────┘  │ │      │  │
    │      │ ││  ┌─────┘ │      └──┼────┐
    │  ┌───┼─┘│  │       │         │    │
    │  │   │  │  │       │         │    │
    v  v   │  │  v       v         v    │
 ┌───────┐ │  │┌───┐ ┌───────┐ ┌──────┐ │
 │ncurses│ │  ││tk │ │openssl│ │libffi│ │
 └───┬───┘ │  │└─┬─┘ └───┬───┘ └───┬──┘ │
     │     │  │  │       │         │    │
     │     │  │  │       └───────┐ │    │
     └─────┼──┼──┼┐              │ │    │
   ┌───────┼──┘  ││              │ │    │
   │       │┌────┘│              │ │    │
   │       ││     │┌─────────────┼─┘    │
   │       ││     ││ ┌───────────┼──────┘
   │       ││     ││ │           │
   v       vv     vv v           v
 ┌───┐ ┌─────┐ ┌───────┐ ┌───────────────┐
 │xz │ │zlib │ │libcxx │ │ca-certificates│
 └───┘ └─────┘ └───────┘ └───────────────┘
```

</details>

<details>

<summary>click dependencies (with pip)</summary>

```
               ┌─────────┐
               │   pip   │
               └─┬─────┬┬┘
                 │^    ││
        ┌────────┘│   ┌┘│
        │         │   │ │
        v         │   │ │
     ┌─────┐      │   │ │
     │wheel│      │   │ │
     └─┬─┬─┘      │   │ │
       │ │        │   │ │
       │ └───┐    │   │ │
       │     │    └───┼─┼┐
       │     │   ┌────┼─┘│
       │     │   │   ┌┼──┘
       │     v   v   ││
       │ ┌──────────┐││
       │ │setuptools│││
       │ └───┬──┬───┘││
       │     │  │    ││
       └─────┼─┐└───┐││
         ┌───┘ │    │││
         │     │    │││
         v     │    │││
     ┌───────┐ │    │││  ┌─────┐
     │certifi│ │    │││  │click│
     └───┬───┘ │    │││  └──┬──┘
         │     │    │││     │
         │     │    ││└┐    │
         └─────┼─┐  ││ │    │
               │ │  ││ │    │
               v v  v│ v    v
           ┌─────────┴───────┐
           │     python      │
           └┬┬┬─────┬──┬─┬─┬┬┘
            │││     │  │ │ ││
            │││     │  │ │ │└──────┐
      ┌─────┼┘│     │  │ │ │       │
      │     │ │     │  │ │ │       │
      v     │ │     │  │ │ │       │
  ┌──────┐  │ │     │  │ │ │       │
  │sqlite│  │ │     │  │ │ │       │
  └─┬──┬─┘  │ │     │  │ │ │       │
    │  │    │ │     │  │ │ │       │
    │  └───┐│ │     │  │ │ └────┐  │
    │ ┌────┼┘ │     │  │ │      │  │
    │ │    v  v     │  │ │      │  │
    │ │ ┌────────┐  │  │ │      │  │
    │ │ │readline│  │  │ │      │  │
    │ │ └────┬───┘  │  │ │      │  │
    │ └────┐ │┌─────┘  │ │      │  │
    │      │ ││  ┌─────┘ │      └──┼────┐
    │  ┌───┼─┘│  │       │         │    │
    │  │   │  │  │       │         │    │
    v  v   │  │  v       v         v    │
 ┌───────┐ │  │┌───┐ ┌───────┐ ┌──────┐ │
 │ncurses│ │  ││tk │ │openssl│ │libffi│ │
 └───┬───┘ │  │└─┬─┘ └───┬───┘ └───┬──┘ │
     │     │  │  │       │         │    │
     │     │  │  │       └───────┐ │    │
     └─────┼──┼──┼┐              │ │    │
   ┌───────┼──┘  ││              │ │    │
   │       │┌────┘│              │ │    │
   │       ││     │┌─────────────┼─┘    │
   │       ││     ││ ┌───────────┼──────┘
   │       ││     ││ │           │
   v       vv     vv v           v
 ┌───┐ ┌─────┐ ┌───────┐ ┌───────────────┐
 │xz │ │zlib │ │libcxx │ │ca-certificates│
 └───┘ └─────┘ └───────┘ └───────────────┘
```

</details>

FWIW, the python/pip cycle created problems for `conda-build`, so even `conda` itself has [special handling][1] of this dependency in at least one place.  (I wrote it.)

[1]: https://github.com/conda/conda/blob/e9a5056/conda/common/toposort.py#L101-L109
[2]: https://github.com/conda/conda/pull/1154
